### PR TITLE
use npm: compile instead of watch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "request": "launch",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "npm: dev",
+            "preLaunchTask": "npm: compile",
             "presentation": {
                 "hidden": false,
                 "group": "",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "request": "launch",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "npm: watch",
+            "preLaunchTask": "npm: dev",
             "presentation": {
                 "hidden": false,
                 "group": "",
@@ -76,7 +76,7 @@
             "name": "Debug Extension and Python",
             "configurations": ["Python debug server (hidden)", "Debug Extension (hidden)"],
             "stopAll": true,
-            "preLaunchTask": "npm: watch",
+            "preLaunchTask": "npm: compile",
             "presentation": {
                 "hidden": false,
                 "group": "",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,20 @@
         },
         {
             "type": "npm",
+            "script": "compile",
+
+            // "isBackground": true,
+            "presentation": {
+                "reveal": "never",
+                "group": "watchers"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "npm",
             "script": "watch-tests",
             "problemMatcher": "$tsc-watch",
             "isBackground": true,


### PR DESCRIPTION
Update the step to use `npm compile` instead of `npm: watch` as this is a one-off process. It's better if we can find a way to actually make the `npm:watch` process works, but I don't know enough about npm/vscode specific config at the moment.