### PR TITLE
Make pipeline discovery more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+# 0.0.4
+- Expanded pipeline discovery to support `*pipeline*.py` patterns and improved handling of nested subdirectories.
+
 # 0.0.3
 - Add catalog config preview for mouse hover.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Use `Cmd` (Mac)/ `Ctrl` (Window) + `Click` or `F12` to trigger `Go to Definition
 - Use the shortcut `Shift` + `F12`
 ![find reference](assets/lsp-find-reference.gif)
 
+Note: You can find pipeline reference in all the files containing "pipeline" in their names, even in nested subdirectories. 
+`
+- pipelines
+  - sub_pipeline
+    - pipeline_data_processing.py
+    - sub_pipeline_1
+        - pipeline_data_processing_1.py
+`
+
 ## Autocompletion in Python
 Type `"` in any `pipeline.py` and it should trigger the autocompletion list.
 ![autocompletion](assets/lsp-autocompletion.gif)

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Use `Cmd` (Mac)/ `Ctrl` (Window) + `Click` or `F12` to trigger `Go to Definition
 - Use the shortcut `Shift` + `F12`
 ![find reference](assets/lsp-find-reference.gif)
 
-Note: You can find pipeline reference in all the files containing "pipeline" in their names, even in nested subdirectories. 
-`
+**Note:** You can find pipeline reference in all the files containing "pipeline" in their names, even in nested subdirectories. 
+```
 - pipelines
   - sub_pipeline
     - pipeline_data_processing.py
     - sub_pipeline_1
         - pipeline_data_processing_1.py
-`
+```
 
 ## Autocompletion in Python
 Type `"` in any `pipeline.py` and it should trigger the autocompletion list.

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import copy
+import glob
 import json
 import os
 import pathlib
@@ -531,20 +532,22 @@ def references(
 
     pipelines_package = importlib_resources.files(f"{PACKAGE_NAME}.pipelines")
 
-    # Iterate on pipeplines/<pipeline_name>/pipeline.py
+    # Iterate on pipelines/<pipeline_name>/**/*pipeline*.py
     result = []
     for pipeline_dir in pipelines_package.iterdir():
         if not pipeline_dir.is_dir():
             continue
-        pipeline_file = pipeline_dir / "pipeline.py"
-        if not pipeline_file.exists():
-            continue
+        # Use glob to find files matching the pattern recursively
+        pipeline_files = glob.glob(f"{pipeline_dir}/**/*pipeline*.py", recursive=True)
+        for pipeline_file in pipeline_files:
+            if not os.path.exists(pipeline_file):
+                continue
 
-        # Read the line number and match keywords naively
-        with open(pipeline_file) as f:
-            for i, line in enumerate(f):
-                if word in line:
-                    result.append((pipeline_file, i))
+            # Read the line number and match keywords naively
+            with open(pipeline_file) as f:
+                for i, line in enumerate(f):
+                    if word in line:
+                        result.append((Path(pipeline_file), i))
 
     locations = []
     if result:

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -540,9 +540,6 @@ def references(
         # Use glob to find files matching the pattern recursively
         pipeline_files = glob.glob(f"{pipeline_dir}/**/*pipeline*.py", recursive=True)
         for pipeline_file in pipeline_files:
-            if not os.path.exists(pipeline_file):
-                continue
-
             # Read the line number and match keywords naively
             with open(pipeline_file) as f:
                 for i, line in enumerate(f):


### PR DESCRIPTION
Resolves https://github.com/kedro-org/vscode-kedro/issues/18

This PR improves the Kedro extension's ability to detect and navigate to pipeline files by supporting more flexible file naming conventions.

- Updated the references function to use glob with recursive=True, allowing it to find all files containing "pipeline" in their names, even in nested subdirectories.
- Replaced the fixed check for pipeline.py with a pattern match for *pipeline\*.py.

Now it Supports non-standard modular pipeline structures.
```
- pipelines
  - sub_pipeline
    - pipeline_data_processing.py
    - sub_pipeline_1
        - pipeline_data_processing_1.py
```