### PR TITLE
LSP now read `KEDRO_ENV`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ p.s. If you can `kedro run` with the environment, you are good to go.
 
 The extension requires `bootstrap_project` in Kedro, you need to make sure you can do `kedro run` without getting any immediate error, otherwise you may get a server panic error.
 
+## Settings
+### Change Configuration Environment
+By default the extension look at the config loader's `base_env` (`base`) usually. If you want it to find configuration from other environment, there are two ways to change:
+1. VSCode extension settings (TBD)
+2. Set `KEDRO_ENV` and launch VSCode.
+
+
 ## How to restart a server if there are error
 Click `Output` and select `Kedro` from the dropdown list. It may gives you some hints and report back if you think this is a bug.
 
@@ -22,10 +29,9 @@ Hit `Cmd` + `Shift` + `P` to open the VSCode command, look for `kedro: restart s
 
 ## Assumptions
 ### Configuration Source
-Currently, the extension assume the source of configuration is `conf/base`. If you have customised `CONF_SOURCE` in project settings, certain features will not be functional properly.
+Currently, the extension assume the source of configuration is in the `base_env` defined by the config loader (if you didn't speficy, [usually it is `conf/base`](https://docs.kedro.org/en/stable/configuration/configuration_basics.html#configuration-loading)). 
 
-### Configuration Environment
-The extension assumes `base` environment. However, you may want it to use different environments. This is still WIP.
+This mean that if the configuration is overrided by the `default_run_env`(usually it is `local`), the extension may fails to resolve to the correct location.
 
 ### Pipeline Discovery
 The extension follows Kedro [pipeline autodiscovery mechanism](https://docs.kedro.org/en/stable/nodes_and_pipelines/pipeline_registry.html#pipeline-autodiscovery). It means that in general it is looking for modular pipelines structure, i.e. `<src/package/pipelines/<pipeline>`. It can be visualised as follows:
@@ -70,5 +76,5 @@ Type `"` in any `pipeline.py` and it should trigger the autocompletion list.
 ![schema validation](assets/lsp-schema-validation.gif)
 
 ## Hover
-Just hover your mouse over any `params:` or hit the command `Show or Focus Hover`
+Just hover your mouse over any `params:`, datasets or hit the command `Show or Focus Hover`
 ![hover](assets/lsp-hover.gif)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -175,18 +175,21 @@ class KedroLanguageServer(LanguageServer):
             session._hook_manager = _NullPluginManager()
             context = session.load_context()
             config_loader: OmegaConfigLoader = context.config_loader
-            base_env = config_loader.base_env
+            # context.env is set when KEDRO_ENV or kedro run --env is set
+            env = context.env if context.env else config_loader.base_env
+            base_path = str(Path(config_loader.conf_source) / env)
+
         except RuntimeError:
             project_metadata = None
             context = None
             config_loader = None
-            base_env = None
+            base_path = None
         finally:
             self.project_metadata = project_metadata
             self.context = context
             self.config_loader = config_loader
             self.dummy_catalog = self._get_dummy_catalog()
-            self.base_env = base_env
+            self.base_path = base_path
 
     def _get_dummy_catalog(self):
         # '**/catalog*' reads modular pipeline configs
@@ -292,7 +295,7 @@ def _check_project():
 
 
 ### Kedro LSP logic
-def get_conf_paths(project_metadata):
+def get_conf_paths(lsp):
     """
     Get the configuration paths of data catalog based on the project metadata.
 
@@ -303,7 +306,7 @@ def get_conf_paths(project_metadata):
         A set of configuration paths.
 
     """
-    config_loader: OmegaConfigLoader = LSP_SERVER.config_loader
+    config_loader: OmegaConfigLoader = lsp.config_loader
     patterns = config_loader.config_patterns.get("catalog", [])
     base_path = str(Path(config_loader.conf_source) / config_loader.base_env)
 
@@ -410,7 +413,7 @@ def definition(
     server: KedroLanguageServer, params: TextDocumentPositionParams
 ) -> Optional[List[Location]]:
     """Support Goto Definition for a dataset or parameter.
-    Currently assume catalog is located in `Path(config_loader.conf_source) / config_loader.base_env)`
+    Currently assume catalog is located in server.base_path
     """
     _check_project()
     if not server.is_kedro_project():
@@ -429,7 +432,7 @@ def definition(
             log_for_lsp_debug(f"{param_location=}")
             return [param_location]
 
-    catalog_paths = get_conf_paths(server.project_metadata)
+    catalog_paths = get_conf_paths(server)
 
     catalog_word = document.word_at_position(params.position)
     log_for_lsp_debug(f"Attempt to search `{catalog_word}` from catalog")
@@ -453,18 +456,10 @@ def definition(
             log_for_lsp_debug(f"{location=}")
             return [location]
 
-    # pos = params.position
-    # fake_location = Location(uri = params.text_document.uri, range = Range(
-    #             start= Position(line= pos.line, character=pos.character ),
-    #             # end = Position(line= pos.line, character=pos.character )
-    #             )
-    # )
     uri = params.text_document.uri
     pos = params.position
     curr_pos = Position(line=pos.line, character=pos.character)
     return Location(uri=uri, range=Range(start=curr_pos, end=curr_pos))
-    # return params
-    # return None
 
 
 def reference_location(path, line):
@@ -558,15 +553,9 @@ def completions(server: KedroLanguageServer, params: CompletionParams):
     for item in server.dummy_catalog.list():
         completion_items.append(CompletionItem(label=item))
 
-    # todo: use MarkedUpContent
     return CompletionList(
         is_incomplete=False,
         items=completion_items,
-        # items=[
-        #     CompletionItem(label='model_options'),
-        #     CompletionItem(label='train_test_split_ratio'),
-        #     CompletionItem(label='learning_rate'),
-        # ]
     )
 
 

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -32,8 +32,8 @@ update_sys_path(
 )
 after_update_path = sys.path.copy()
 
-logger.warn(f"{before_update_path=}")
-logger.warn(f"{after_update_path=}")
+logger.warning(f"{before_update_path=}")
+logger.warning(f"{after_update_path=}")
 # **********************************************************
 # Imports needed for the language server goes below this.
 # **********************************************************


### PR DESCRIPTION
Part of #14 

Previously the config will read from `config_loader.base_env`, which miss the path that `KEDRO_ENV` can change the "default" env. This is more consistent to a Kedro project.