### PR TITLE
Don't sort dictionary during pprint

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,6 +7,7 @@
 tasks:
   - init: |
       npm install && npm run compile && pip install -r requirements.txt
+      npm install -g @vscode/vsce
       make sign-off
     command: npm run watch
 

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -594,7 +594,7 @@ def hover(ls: KedroLanguageServer, params: HoverParams):
         # parameters
         hover_content = ls.dummy_catalog.load(word)
 
-    hover_content = pprint.pformat(hover_content)
+    hover_content = pprint.pformat(hover_content, sort_dicts=False)
     highlight = _highlight(hover_content)
 
     return Hover(


### PR DESCRIPTION
> i think (but am not 100% sure) there might be a small and almost always inconsequential bug in the kedro vscode plugin, around displaying the order of elements in dictionaries within config parameters. It seems like it doesn't always display in the same order as the dictionary would actually be created.

This is reported by an user, so the fix is simply don't sort the dictionary. (It was not intended but I am not aware of the default settings of pprint)