### PR TITLE
Check if Python dependencies is installed before setting flag 

### DIFF
--- a/src/common/callPythonScript.ts
+++ b/src/common/callPythonScript.ts
@@ -9,8 +9,8 @@ import { getInterpreterDetails } from './python';
  * @param context - The context object.
  * @returns A promise that resolves when the script execution is complete.
  */
-export async function callPythonScript(pathToScript: string, scriptArgv: string, context: any): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
+export async function callPythonScript(pathToScript: string, scriptArgv: string, context: any): Promise<string> {
+    return new Promise<string>(async (resolve, reject) => {
         const script = context.asAbsolutePath(pathToScript);
         const interpreterDetails = await getInterpreterDetails();
         const pythonPath = interpreterDetails['path'] && interpreterDetails['path'][0];
@@ -21,7 +21,7 @@ export async function callPythonScript(pathToScript: string, scriptArgv: string,
                 reject(error);
             } else {
                 console.log(stdout);
-                resolve();
+                resolve(stdout);
             }
         });
     });

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -76,11 +76,14 @@ export async function installDependenciesIfNeeded(context: vscode.ExtensionConte
     if (!alreadyInstalled) {
         const pathToScript = 'bundled/tool/install_dependencies.py';
         try {
-            await callPythonScript(pathToScript, EXTENSION_ROOT_DIR, context);
-            context.globalState.update('dependenciesInstalled', true);
+            const stdout = await callPythonScript(pathToScript, EXTENSION_ROOT_DIR, context);
 
-            traceLog(`Python dependencies installed!`);
-            console.log('Python dependencies installed!');
+            // Check if the script output contains the success message
+            if (stdout.includes('Successfully installed')) {
+                context.globalState.update('dependenciesInstalled', true);
+                traceLog(`Python dependencies installed!`);
+                console.log('Python dependencies installed!');
+            }
         } catch (error) {
             traceError(`Failed to install Python dependencies:: ${error}`);
             console.error(`Failed to install Python dependencies:: ${error}`);


### PR DESCRIPTION
## Description

This PR improves the `callPythonScript` function and updates its usage in the codebase.

## Dev Note


- `callPythonScript` now returns a Promise\<string> instead of Promise\<void>, allowing it to resolve with the script's output (stdout).

- Updated `installDependenciesIfNeeded` to check the script's output for a success message and update the the `dependenciesInstalled` flag.