### PR TITLE
Kedro viz dependencies version check

### DIFF
--- a/bundled/tool/install_dependencies.py
+++ b/bundled/tool/install_dependencies.py
@@ -17,7 +17,23 @@ def install_dependencies(extension_root_dir):
 
     try:
         import fastapi
+        import pydantic
         import orjson
+        from packaging.version import parse
+
+        fastapi_version = parse(fastapi.__version__)
+        if fastapi_version < parse("0.100.0") or fastapi_version >= parse("0.200.0"):
+            raise ImportError("fastapi version must be >=0.100.0 and <0.200.0")
+        
+
+        pydantic_version = parse(pydantic.__version__)
+        if pydantic_version < parse("2.0.0"):
+            raise ImportError("Pydantic version must be >= 2.0.0")      
+
+        orjson_version = parse(orjson.__version__)
+        if orjson_version < parse("3.9") or orjson_version >= parse("4.0"):
+            raise ImportError("orjson version must be >= 3.9 and < 4.0")    
+             
     except ImportError:
         subprocess.check_call(
             [


### PR DESCRIPTION
## Description

In this PR we are checking Kedro viz dependencies version to avoid version miss match with user's install dependencies. 

```
        fastapi_version = parse(fastapi.__version__)
        if fastapi_version < parse("0.100.0") or fastapi_version >= parse("0.200.0"):
            raise ImportError("fastapi version must be >=0.100.0 and <0.200.0")


        pydantic_version = parse(pydantic.__version__)
        if pydantic_version < parse("2.0.0"):
            raise ImportError("Pydantic version must be >= 2.0.0")      

        orjson_version = parse(orjson.__version__)
        if orjson_version < parse("3.9") or orjson_version >= parse("4.0"):
            raise ImportError("orjson version must be >= 3.9 and < 4.0")

```
