### PR TITLE
Bug fix - definition on parameters is not working

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -224,7 +224,7 @@ def _get_conf_paths(server: KedroLanguageServer, key):
 
 
 def _get_param_location(
-    project_metadata: ProjectMetadata, word: str
+    server: KedroLanguageServer, word: str
 ) -> Optional[Location]:
     words = word.split("params:")
     if len(words) > 1:
@@ -234,7 +234,7 @@ def _get_param_location(
     log_to_output(f"Attempt to search `{param}` from parameters file")
 
     # TODO: cache -- we shouldn't have to re-read the file on every request
-    params_paths = _get_conf_paths(project_metadata, "parameters")
+    params_paths = _get_conf_paths(server, "parameters")
     param_line_no = None
 
     for parameters_file in params_paths:


### PR DESCRIPTION
I notice the Go to definition is breaking when query `params:xxxx` in `pipeline.py`. This is caused by a bug during refactoring a few weeks ago.