### PR TITLE
Update flowchart on Kedro/LSP server restart

### DIFF
--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -4,12 +4,15 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
 import { LogLevel, Uri, WorkspaceFolder } from 'vscode';
 import { Trace } from 'vscode-jsonrpc/node';
 import { getWorkspaceFolders } from './vscodeapi';
 import { callPythonScript } from './callPythonScript';
 import { EXTENSION_ROOT_DIR } from './constants';
 import { traceError, traceLog } from './log/logging';
+import { executeGetProjectDataCommand } from './commands';
+import KedroVizPanel from '../webview/vizWebView';
 
 function logLevelToTrace(logLevel: LogLevel): Trace {
     switch (logLevel) {
@@ -89,4 +92,9 @@ export async function installDependenciesIfNeeded(context: vscode.ExtensionConte
             console.error(`Failed to install Python dependencies:: ${error}`);
         }
     }
+}
+
+export async function updateKedroVizPanel(lsClient: LanguageClient | undefined): Promise<void> {
+    const projectData = await executeGetProjectDataCommand(lsClient);
+    KedroVizPanel.currentPanel?.updateData(projectData);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ import { restartServer } from './common/server';
 import { checkIfConfigurationChanged, getInterpreterFromSetting } from './common/settings';
 import { loadServerDefaults } from './common/setup';
 import { createStatusBar } from './common/status_bar';
-import { getLSClientTraceLevel, installDependenciesIfNeeded } from './common/utilities';
+import { getLSClientTraceLevel, installDependenciesIfNeeded, updateKedroVizPanel } from './common/utilities';
 import { createOutputChannel, onDidChangeConfiguration, registerCommand } from './common/vscodeapi';
 import KedroVizPanel from './webview/vizWebView';
 
@@ -71,8 +71,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     context.subscriptions.push(
         registerCommand(CMD_RUN_KEDRO_VIZ, async () => {
             KedroVizPanel.createOrShow(context.extensionUri);
-            const projectData = await executeGetProjectDataCommand(lsClient);
-            KedroVizPanel.currentPanel?.updateData(projectData);
+            updateKedroVizPanel(lsClient);
         }),
     );
 
@@ -126,6 +125,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }),
         registerCommand(CMD_RESTART_SERVER, async () => {
             await runServer();
+
+            // If KedroVizPanel is open, update the data on server restart
+            if (KedroVizPanel.currentPanel) {
+                updateKedroVizPanel(lsClient);
+            }
         }),
         registerCommand(CMD_SELECT_ENV, async () => {
             const result = await selectEnvironment();


### PR DESCRIPTION
## Description

This PR focus on updating flowchart with latest Kedro project data when Kedro-Viz flowchart is already opened. User can update the flowchart with command `"kedro: Restart Server"` after done with Kedro project changes.

## Dev notes

- On Kedro server restart command if Kedro-Viz flowchart is already open we are fetching latest data and passing it to webview.