### PR TITLE
Bug fix: Statur bar text after changing environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 # 0.2.0
 - `Select Environment` actions now update the run environment instead of base.
 - Modified status bar to show both environments, i.e.`base + local`, and `base` is no longer selectable.
+- Fixed a minor bug where status bar showing incorrect text, i.e. it shows `prod` insteadf of `base + prod`.
 
 # 0.1.0
 - Expanded pipeline discovery to support `*pipeline*.py` patterns and improved handling of nested subdirectories.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             const result = await selectEnvironment();
             runServer(result);
             if (result) {
-                statusBarItem.text = `$(kedro-logo)` + ' ' + result.label;
+                statusBarItem.text = `$(kedro-logo) base + ${result.label}`;
             }
         }),
         registerCommand('pygls.server.executeCommand', async () => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/62f56f0b-c5f1-4792-86d1-f8721b285b28)

In previous PR we fixed the environment to be `base + {env}`, the status bar is not showing the base anymore after user change environment.
