### PR TITLE
Remove the non-user facing command for showing up

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,11 +159,6 @@
                 "category": "pygls"
             },
             {
-                "title": "Send Definition Request",
-                "category": "kedro",
-                "command": "kedro.sendDefinitionRequest"
-            },
-            {
                 "command": "kedro.runKedroViz",
                 "category": "kedro",
                 "title": "Run Kedro Viz"


### PR DESCRIPTION
The command is used by webview and testing previously, we don't need this for release. (would be nice if it can be registered as a command only in debug mode, I can't find anything so I just remove it)