### PR TITLE
[Bug Fix] - reference returns too many matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `Select Environment` actions now update the run environment instead of base.
 - Modified status bar to show both environments, i.e.`base + local`, and `base` is no longer selectable.
 - Fixed a minor bug where status bar showing incorrect text, i.e. it shows `prod` insteadf of `base + prod`.
+- Fixed a bug where "Find reference" return too many matches for catalog dataset, it returns only exact matches now.
 
 # 0.1.0
 - Expanded pipeline discovery to support `*pipeline*.py` patterns and improved handling of nested subdirectories.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The extension follows Kedro [pipeline autodiscovery mechanism](https://docs.kedr
 ## Visualisation with Kedro-Viz
 To visualize your Kedro project using Kedro-Viz in Visual Studio Code, follow these steps:
 
-1. **Open the Command Palette**: 
+1. **Open the Command Palette**:
 Press `Cmd` + `Shift` + `P` (on macOS) or `Ctrl` + `Shift` + `P` (on Windows/Linux).
 
 2. **Run Kedro-Viz**:
@@ -80,7 +80,7 @@ Use `Cmd` (Mac)/ `Ctrl` (Window) + `Click` or `F12` to trigger `Go to Definition
 - Use the shortcut `Shift` + `F12`
 ![find reference](assets/lsp-find-reference.gif)
 
-**Note:** You can find pipeline reference in all the files containing "pipeline" in their names, even in nested subdirectories.
+**Note:** You can find pipeline reference in all the python files under `<package_name>/pipelines`
 ```
 - pipelines
   - sub_pipeline

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -377,7 +377,7 @@ def references(
         if not pipeline_dir.is_dir():
             continue
         # Use glob to find files matching the pattern recursively
-        pipeline_files = glob.glob(f"{pipeline_dir}/**/*pipeline*.py", recursive=True)
+        pipeline_files = glob.glob(f"{pipeline_dir}/**/*.py", recursive=True)
         for pipeline_file in pipeline_files:
             # Read the line number and match keywords naively
             with open(pipeline_file) as f:

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -382,7 +382,7 @@ def references(
             # Read the line number and match keywords naively
             with open(pipeline_file) as f:
                 for i, line in enumerate(f):
-                    if word in line:
+                    if f'"{word}"' in line:
                         result.append((Path(pipeline_file), i))
 
     locations = []

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "Kedro",
     "displayName": "Kedro",
     "description": "A Kedro VSCode Extension.",
-    "version": "0.2.0-rc0",
+    "version": "0.2.0-rc3",
     "preview": false,
     "serverInfo": {
         "name": "Kedro",


### PR DESCRIPTION
# Description
<img width="865" alt="image" src="https://github.com/user-attachments/assets/0dbafac8-06b3-4544-aa57-fd30e9c9448d">

The example use `spaceflights` project and when I use "Find reference" on `companies`, it returns `companies` but also `preprocessed_companies`.

# Context
 This makes the feature unusable with larger project because it returns too many matches. It should return exact match only.


# Changes
1. Instead of searching `companies`, it now search for `"companies"` to avoid too many mismatches.
2. It search more files now, anything inside `pipelines` will be search since many complex project simply don't use `nodes.py` and `pipelines.py` and it's hard to determine whether a file only contains node or pipeline.

2 causes more files being search and 1 narrow down the matches. Result for `spaceflights` as follow:
<img width="846" alt="image" src="https://github.com/user-attachments/assets/38513880-b5ae-462d-b941-17d1e6aed306">
