### PR TITLE
Expand pipeline search folders in all <package_name>/pipelines/ folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where "Find reference" return too many matches for catalog dataset, it returns only exact matches now.
 - Fixed a bug where namespace dataset navigation is not working properly
 - Fixed a bug where navigating on nested parameters should go to the top level key.
+- Modify the extension to search pipelines from all <package_name>/pipelines folder.
 
 
 # 0.1.0

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -290,7 +290,9 @@ def definition(
 
     def _query_catalog(document, word=None):
         if not word:
-            word = document.word_at_position(params.position, RE_START_WORD, RE_END_WORD)
+            word = document.word_at_position(
+                params.position, RE_START_WORD, RE_END_WORD
+            )
         catalog_paths = _get_conf_paths(server, "catalog")
         log_for_lsp_debug(f"Attempt to search `{word}` from catalog")
         log_for_lsp_debug(f"{catalog_paths=}")
@@ -377,19 +379,15 @@ def references(
 
     pipelines_package = importlib_resources.files(f"{PACKAGE_NAME}.pipelines")
 
-    # Iterate on pipelines/<pipeline_name>/**/*pipeline*.py
+    # Iterate on pipelines/**/*.py that fits both modular or flat pipeline structure.
     result = []
-    for pipeline_dir in pipelines_package.iterdir():
-        if not pipeline_dir.is_dir():
-            continue
-        # Use glob to find files matching the pattern recursively
-        pipeline_files = glob.glob(f"{pipeline_dir}/**/*.py", recursive=True)
-        for pipeline_file in pipeline_files:
-            # Read the line number and match keywords naively
-            with open(pipeline_file) as f:
-                for i, line in enumerate(f):
-                    if f'"{word}"' in line:
-                        result.append((Path(pipeline_file), i))
+    pipeline_files = glob.glob(f"{pipelines_package}/**/*.py", recursive=True)
+    for pipeline_file in pipeline_files:
+        # Read the line number and match keywords naively
+        with open(pipeline_file) as f:
+            for i, line in enumerate(f):
+                if f'"{word}"' in line:
+                    result.append((Path(pipeline_file), i))
 
     locations = []
     if result:


### PR DESCRIPTION
Previously the extension only search pipeline for reference in :
- <package_name>/pipelines/<modular_pipeline_name>/pipeline_xxxx.py

This has proven to be too restrictive, as most project that comes with a lot of pipeline abandon the standard structure provided in spaceflights. For example:
- package/pipelines/training.py

This either use the `pipeline_xx` convention and skip the folder and simply put node and pipeline into one file. The change will cause the extension searching more files, but performance seems to be ok.

We need to work on performance improvement later anyway so this is not a big concern for now.