### PR TITLE
Update `get_kedro_project_json_data` import path

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -565,7 +565,12 @@ def definition_from_flowchart(ls, word):
 def get_project_data_from_viz(lsClient):
     """Get project data from kedro viz"""
     from kedro_viz.server import load_and_populate_data
-    from kedro_viz.api.rest.responses import get_kedro_project_json_data
+    try:
+        # For kedro-viz > 10.0.0
+        from kedro_viz.api.rest.responses.pipelines import get_kedro_project_json_data
+    except ImportError as e:
+        # For kedro-viz = 10.0.0
+        from kedro_viz.api.rest.responses import get_kedro_project_json_data
 
     data = None
     try:


### PR DESCRIPTION
## Descriptions 

Resolves https://github.com/kedro-org/vscode-kedro/issues/143

This pull request includes a change to the `bundled/tool/lsp_server.py` file to improve compatibility with different versions of `kedro-viz`. The most important change is the addition of a try-except block to handle imports for `kedro-viz` versions greater than and equal to 10.0.0.

## Developer Note

* [`bundled/tool/lsp_server.py`](diffhunk://#diff-6946ea5cbaa105f584c64a7a929c675768847c8e05c86ce965ca8daa18f0ac73R568-R572): Added a try-except block to import `get_kedro_project_json_data` from the correct module based on the `kedro-viz` version.