### PR TITLE
Silence errors when not on a Kedro project

### DIFF
--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -176,3 +176,21 @@ export async function updateKedroVizPanel(lsClient: LanguageClient | undefined):
     const projectData = await executeGetProjectDataCommand(lsClient);
     KedroVizPanel.currentPanel?.updateData(projectData);
 }
+
+export async function isKedroProject(): Promise<boolean> {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders) {
+      return false;
+    }
+  
+    for (const folder of folders) {
+      const pyprojectPath = path.join(folder.uri.fsPath, 'pyproject.toml');
+      if (fs.existsSync(pyprojectPath)) {
+        const content = fs.readFileSync(pyprojectPath, 'utf8');
+        if (content.includes('[tool.kedro]')) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -178,19 +178,25 @@ export async function updateKedroVizPanel(lsClient: LanguageClient | undefined):
 }
 
 export async function isKedroProject(): Promise<boolean> {
-    const folders = vscode.workspace.workspaceFolders;
-    if (!folders) {
-      return false;
+    const folders = getWorkspaceFolders();
+    if (!folders || folders.length === 0) {
+        return false;
     }
-  
+
+    // Check all workspace folders
     for (const folder of folders) {
-      const pyprojectPath = path.join(folder.uri.fsPath, 'pyproject.toml');
-      if (fs.existsSync(pyprojectPath)) {
-        const content = fs.readFileSync(pyprojectPath, 'utf8');
-        if (content.includes('[tool.kedro]')) {
-          return true;
+        const pyprojectPath = path.join(folder.uri.fsPath, 'pyproject.toml');
+        try {
+            const content = await fs.readFile(pyprojectPath, 'utf8');
+            if (content.includes('[tool.kedro]')) {
+                traceLog(`Kedro project detected in folder: ${folder.uri.fsPath}`);
+                return true;
+            }
+        } catch (error) {
+            // Continue if we can't find/read files
+            traceError(`Error reading ${pyprojectPath}: ${error}`);
+            continue;
         }
-      }
     }
     return false;
-  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import {
     updateKedroVizPanel,
     checkKedroProjectConsent,
     installTelemetryDependenciesIfNeeded,
+    isKedroProject,
 } from './common/utilities';
 import { createOutputChannel, onDidChangeConfiguration, registerCommand } from './common/vscodeapi';
 import KedroVizPanel from './webview/vizWebView';
@@ -29,27 +30,13 @@ import { handleKedroViz } from './webview/createOrShowKedroVizPanel';
 
 let lsClient: LanguageClient | undefined;
 
-import * as fs from 'fs';
-import * as path from 'path';
-
-
-function isKedroProject(workspacePath: string): boolean {
-    const pyprojectPath = path.join(workspacePath, 'pyproject.toml');
-    
-    if (!fs.existsSync(pyprojectPath)) {
-        return false;
-    }
-
-    try {
-        const fileContent = fs.readFileSync(pyprojectPath, 'utf-8');
-        return fileContent.includes('[tool.kedro]'); //check for tool.kedro in toml
-    } catch (error) {
-        console.error("Failed to read pyproject.toml:", error);
-        return false;
-    }
-}
-
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    
+    if (!(await isKedroProject())) {
+        console.log('Kedro VSCode extension: No Kedro project detected.');
+        return;
+    }
+
     await installTelemetryDependenciesIfNeeded(context);
 
     // Check for consent in the Kedro Project

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,8 +31,8 @@ import { handleKedroViz } from './webview/createOrShowKedroVizPanel';
 let lsClient: LanguageClient | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-    
-    if (!(await isKedroProject())) {
+    const _isKedroProject = await isKedroProject();
+    if (!_isKedroProject) {
         console.log('Kedro VSCode extension: No Kedro project detected.');
         return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,26 @@ import { handleKedroViz } from './webview/createOrShowKedroVizPanel';
 
 let lsClient: LanguageClient | undefined;
 
+import * as fs from 'fs';
+import * as path from 'path';
+
+
+function isKedroProject(workspacePath: string): boolean {
+    const pyprojectPath = path.join(workspacePath, 'pyproject.toml');
+    
+    if (!fs.existsSync(pyprojectPath)) {
+        return false;
+    }
+
+    try {
+        const fileContent = fs.readFileSync(pyprojectPath, 'utf-8');
+        return fileContent.includes('[tool.kedro]'); //check for tool.kedro in toml
+    } catch (error) {
+        console.error("Failed to read pyproject.toml:", error);
+        return false;
+    }
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     await installTelemetryDependenciesIfNeeded(context);
 


### PR DESCRIPTION
Related to: https://github.com/kedro-org/vscode-kedro/issues/77 

Uers were experiencing error messages from the Kedro VSCode extension when working in non-Kedro projects. These errors were causing annoyance and could potentially lead users to uninstall the extension due to the unnecessary noise.

### Development Notes:
Introduced a check in the activate function within `extension.ts` to determine if the current workspace is a Kedro project.
The check looks for a `pyproject.toml` file containing the `[tool.kedro]` section.
If the workspace is not a Kedro project, the extension will not activate.

Added `isKedroProject` function from in `utilities` to perform the project detection logic.
