### PR TITLE
Node Re-focus disabled with kedro-viz 10.1 updated

### DIFF
--- a/webview/package.json
+++ b/webview/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@quantumblack/kedro-viz": "^10.0.0",
+    "@quantumblack/kedro-viz": "^10.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1"

--- a/webview/src/App.jsx
+++ b/webview/src/App.jsx
@@ -97,6 +97,9 @@ function App() {
               miniMap: false,
               sidebar: false,
             },
+            behaviour: { 
+              reFocus: false,
+            },
             visible: {
               slicing: false,
             },


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/vscode-kedro/issues/153

This pull request includes updates to dependencies and the addition of a new configuration option in the `App` component. The most important changes include updating the `@quantumblack/kedro-viz` dependency and adding a `behaviour` configuration to the `App` component.

## Development notes

* [`webview/package.json`](diffhunk://#diff-768fcfde96b57f2af582e7c53e023e1532fbcc1c4ed8e1328fef74bedfc5f4f5L6-R6): Updated `@quantumblack/kedro-viz` dependency from version `^10.0.0` to `^10.1.0`.

* [`webview/src/App.jsx`](diffhunk://#diff-7eebeb518139a7bea347e0941b94f78541aee8a123b0a1c00ca7fe4267a46cddR100-R102): Added a new `behaviour` configuration with `reFocus` set to `false` in the `App` component.


**Note:**
Please merge this PR only after Kedro-Viz 10.1.0 release.