### PR TITLE
[SPIKE] Test validate dataset classes in catalog using LSP

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -584,6 +584,9 @@ async def validate_catalog(ls: KedroLanguageServer, uri: str):
             return  # Invalid catalog format
 
         for dataset_name, dataset_config in catalog.items():
+            if dataset_name.startswith('_'):
+                continue  # Skip datasets starting with '_'
+
             dataset_type = dataset_config.get('type')
             if dataset_type:
                 is_importable, error_msg = is_dataset_importable(dataset_type)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -526,6 +526,12 @@ def did_change_configuration(
 async def did_open(ls: KedroLanguageServer, params: DidOpenTextDocumentParams):
     """Validate catalog content when a file is opened."""
     document_uri = params.text_document.uri
+    file_path = pathlib.Path(uris.to_fs_path(document_uri))
+
+    # Only validate files with 'catalog' in the name and YAML extensions
+    if not (file_path.name.startswith("catalog") and file_path.suffix in {".yml", ".yaml"}):
+        return
+
     document = ls.workspace.get_text_document(document_uri)
     await validate_catalog_content(ls, document_uri, document.source)
 
@@ -534,6 +540,12 @@ async def did_open(ls: KedroLanguageServer, params: DidOpenTextDocumentParams):
 async def did_change(ls: KedroLanguageServer, params: DidChangeTextDocumentParams):
     """Validate the catalog file live on every change."""
     document_uri = params.text_document.uri
+    file_path = pathlib.Path(uris.to_fs_path(document_uri))
+
+    # Only validate files with 'catalog' in the name and YAML extensions
+    if not (file_path.name.startswith("catalog") and file_path.suffix in {".yml", ".yaml"}):
+        return
+
     document = ls.workspace.get_text_document(document_uri)
     updated_content = document.source  # Live content of the file
     await validate_catalog_content(ls, document_uri, updated_content)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -674,7 +674,6 @@ async def validate_catalog(ls: KedroLanguageServer, uri: str):
 async def periodic_revalidation(ls: KedroLanguageServer, interval: int = 5):
     """Periodically revalidate all catalog files."""
     while True:
-        log_to_output("Periodic check: Revalidating catalogs...")
         try:
             await validate_all_catalogs(ls)
         except Exception as e:

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -90,6 +90,11 @@ async function createServer(
                   { scheme: 'untitled', language: 'python' },
                   { scheme: 'vscode-notebook', language: 'python' },
                   { scheme: 'vscode-notebook-cell', language: 'python' },
+                  {
+                    scheme: 'file',
+                    language: 'yaml',
+                    pattern: '**/catalog*.yml',
+                },
               ],
         outputChannel: outputChannel,
         traceOutputChannel: outputChannel,


### PR DESCRIPTION
Related to: https://github.com/kedro-org/vscode-kedro/issues/5

This is a spike to test using the lamguage server protocol from pygls to add validation for dataset classes.


# How to Use the Feature

1. Install or Update the Kedro VSCode Extension
2. Open Your Kedro Project in VSCode
3. The extension will automatically initialize and start scanning catalog files.
4. View Diagnostics in the Problems Pane it will display diagnostics for any issues found in your catalog files, even if the files are not open.