### PR TITLE
Update Kedro-Viz to 11.0.0 as minimum requirement for extension

### DIFF
--- a/bundled/tool/check_viz_dependencies.py
+++ b/bundled/tool/check_viz_dependencies.py
@@ -14,8 +14,8 @@ def check_kedro_viz():
         from packaging.version import parse
 
         kedro_viz_version = parse(kedro_viz.__version__)
-        if kedro_viz_version < parse("10.0.0"):
-            raise ImportError("Missing dependencies: kedro_viz version must be >= 10.0.0")        
+        if kedro_viz_version < parse("11.0.0"):
+            raise ImportError("Missing dependencies: kedro_viz version must be >= 11.0.0")        
 
     except ImportError as e:
         print("Missing dependencies: ", e)

--- a/kedro-viz-requirements.txt
+++ b/kedro-viz-requirements.txt
@@ -1,1 +1,1 @@
-kedro-viz>=10.1.0
+kedro-viz>=11.0.0

--- a/src/webview/createOrShowKedroVizPanel.ts
+++ b/src/webview/createOrShowKedroVizPanel.ts
@@ -23,7 +23,7 @@ export async function handleKedroViz(
     } else {
         const header = 'Kedro-Viz Dependency Required';
         const options: vscode.MessageOptions = {
-            detail: 'Kedro-Viz version 10.1.0 or later is required to visualize your project\'s data pipeline. It’s not installed in your virtual environment. Click "Install" to set it up with pip.',
+            detail: 'Kedro-Viz version 11.0.0 or later is required to visualize your project\'s data pipeline. It’s not installed in your virtual environment. Click "Install" to set it up with pip.',
             modal: true,
         };
 

--- a/webview/src/App.jsx
+++ b/webview/src/App.jsx
@@ -11,7 +11,7 @@ function App() {
   const toolbarOptions = {
     labelBtn: true,
     layerBtn: true,
-    expandPipelinesBtn: false,
+    expandPipelinesBtn: true,
     exportBtn: false,
     filterBtn: true,
   };


### PR DESCRIPTION
## Description

This pull request updates the minimum required version of Kedro-Viz across the project to ensure compatibility with new features and improvements. 

For the lower version it will break with below error
```
2025-03-14 11:14:09.762 [info] [Error - 11:14:09] Kedro-Viz: get_kedro_project_json_data() got an unexpected keyword argument 'pipeline_name'
```

This version update is mandatory for filter pipeline feature to work.

After Kedro VSCode `0.4.0` release, user will be prompt with

<img width="264" alt="Screenshot 2025-03-14 at 11 30 51 a m" src="https://github.com/user-attachments/assets/515825d7-fa46-4496-8a1f-3ef6eb7eb030" />
  
## Development notes

Version updates:

* [`bundled/tool/check_viz_dependencies.py`](diffhunk://#diff-dd2841ce1d2faca6efa5425adf29b95353d132c9fb99ce2b84c9fa7aed3870cdL17-R18): Updated the minimum required version of Kedro-Viz from 10.0.0 to 11.0.0 in the `check_kedro_viz` function.
* [`kedro-viz-requirements.txt`](diffhunk://#diff-e3fa19a6425caf8bf4b43cfaeb22269c31fb02aaa291ce8a7eddc0ae809e8417L1-R1): Updated the minimum required version of Kedro-Viz from 10.1.0 to 11.0.0.

User prompt update:

* [`src/webview/createOrShowKedroVizPanel.ts`](diffhunk://#diff-d5a2c4af3b55033ba1e86924f04e3ec030d00fbf91ac172e220ae278fe74148bL26-R26): Updated the version detail in the message prompt to require Kedro-Viz version 11.0.0 or later.