### PR TITLE
Add Kedro 1.0 compatibility for DataCatalog API changes

### DIFF
--- a/bundled/tool/_lsp_server.py
+++ b/bundled/tool/_lsp_server.py
@@ -7,15 +7,31 @@ from yaml.loader import SafeLoader
 class DummyDataCatalog(DataCatalog):
     """Only host the config of the DataCatalog but not actually loading the dataset class"""
 
-    def __init__(self, conf_catalog, feed_dict):
+    def __init__(self, conf_catalog, feed_dict=None):
         datasets = {}
         self.conf_catalog = conf_catalog
-        self._params = feed_dict
+        self._params = feed_dict or {}
 
         for ds_name, ds_config in conf_catalog.items():
             datasets[ds_name] = ds_config
 
         super().__init__(datasets=datasets)
+
+        if feed_dict:
+            self._initialise_params()
+
+    def _initialise_params(self):
+        """Add parameter datasets to the catalog"""
+        feed_dict = self._get_feed_dict()
+        for key, value in feed_dict.items():
+            if key not in self._datasets:
+                self._datasets[key] = value
+
+    def add_feed_dict(self, feed_dict: dict[str, Any]) -> None:
+        """Compatibility method for Kedro 1.0+"""
+        for key, value in feed_dict.items():
+            if key not in self._datasets:
+                self._datasets[key] = value
 
     @property
     def params(self):

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -151,11 +151,9 @@ class KedroLanguageServer(LanguageServer):
         # '**/catalog*' reads modular pipeline configs
         conf_catalog = self.config_loader["catalog"]
         params = self.config_loader["parameters"]
-        catalog: DummyDataCatalog = DummyDataCatalog(
-            conf_catalog=conf_catalog, feed_dict=params
-        )
-        feed_dict = catalog._get_feed_dict()
-        catalog.add_feed_dict(feed_dict)
+        
+        # The DummyDataCatalog now handles internally
+        catalog = DummyDataCatalog(conf_catalog=conf_catalog, feed_dict=params)
         return catalog
 
 


### PR DESCRIPTION
## Description
Fixes compatibility with Kedro 1.0 by handling the removal of `add_feed_dict()` method from DataCatalog API.

## Problem
Users on Kedro 1.0 were getting `AttributeError: 'DummyDataCatalog' object has no attribute 'add_feed_dict'` when the extension tried to initialise, making the extension completely unusable.