### PR TITLE
Auto reload Kedro-Viz on Kedro project file change

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
                     "scope": "resource",
                     "type": "string"
                 },
-                "kedro.autoReloadViz": {
+                "kedro.autoReloadKedroViz": {
                     "default": false,
                     "description": "Automatically reload Kedro Viz when Kedro project files change.",
                     "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,12 @@
                     "description": "Custom path to Kedro project root directory. Please add absolute path to your Kedro project root directory.",
                     "scope": "resource",
                     "type": "string"
+                },
+                "kedro.autoReloadViz": {
+                    "default": false,
+                    "description": "Automatically reload Kedro Viz when Kedro project files change.",
+                    "scope": "resource",
+                    "type": "boolean"
                 }
             }
         },

--- a/src/common/activationHelper.ts
+++ b/src/common/activationHelper.ts
@@ -14,6 +14,7 @@ import { checkVersion, getInterpreterDetails, onDidChangePythonInterpreter, reso
 import { sendHeapEventWithMetadata } from './telemetry';
 import { restartServer } from './server';
 import { checkIfConfigurationChanged, getInterpreterFromSetting } from './settings';
+import { setupKedroProjectFileWatchers } from './kedroProjectFileWatchers';
 import { loadServerDefaults } from './setup';
 import { createStatusBar } from './status_bar';
 import { getLSClientTraceLevel, updateKedroVizPanel } from './utilities';
@@ -126,6 +127,11 @@ export const registerCommandsAndEvents = (
                 setLSClient(newClient);
             }),
             onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
+                // Handle autoReloadViz setting change specifically
+                if (e.affectsConfiguration(`${serverId}.autoReloadViz`)) {
+                    setupKedroProjectFileWatchers(context);
+                }
+
                 if (checkIfConfigurationChanged(e, serverId)) {
                     const newClient = await runServer(getLSClient());
                     setLSClient(newClient);

--- a/src/common/activationHelper.ts
+++ b/src/common/activationHelper.ts
@@ -127,8 +127,8 @@ export const registerCommandsAndEvents = (
                 setLSClient(newClient);
             }),
             onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
-                // Handle autoReloadViz setting change specifically
-                if (e.affectsConfiguration(`${serverId}.autoReloadViz`)) {
+                // Handle autoReloadKedroViz setting change specifically
+                if (e.affectsConfiguration(`${serverId}.autoReloadKedroViz`)) {
                     setupKedroProjectFileWatchers(context);
                 }
 

--- a/src/common/kedroProjectFileWatchers.ts
+++ b/src/common/kedroProjectFileWatchers.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import { traceLog } from './log/logging';
 import KedroVizPanel from '../webview/vizWebView';
 
-// Simple restart prevention
 let isRestartInProgress = false;
 
 /**
@@ -18,7 +17,7 @@ export function setupKedroProjectFileWatchers(context: vscode.ExtensionContext):
 
     const handleFileChange = (uri: vscode.Uri, changeType: string) => {
         traceLog(`${changeType}: ${uri.fsPath}`);
-        handleKedroProjectChange(uri, changeType);
+        handleKedroProjectChange(changeType);
     };
 
     // Set up change listeners
@@ -35,9 +34,7 @@ export function setupKedroProjectFileWatchers(context: vscode.ExtensionContext):
 /**
  * Handler for Kedro project file changes, Also prevents overlapping server restarts
  */
-async function handleKedroProjectChange(uri: vscode.Uri, changeType: string): Promise<void> {
-    console.log(`${changeType}: ${uri.fsPath}`);
-
+async function handleKedroProjectChange(changeType: string): Promise<void> {
     // Only update if KedroViz panel is currently open
     if (!KedroVizPanel.currentPanel) {
         traceLog('KedroViz panel not open, skipping update');
@@ -46,13 +43,13 @@ async function handleKedroProjectChange(uri: vscode.Uri, changeType: string): Pr
 
     // If restart is already in progress, ignore this change
     if (isRestartInProgress) {
-        traceLog(`Server restart already in progress, ignoring ${changeType.toLowerCase()}`);
+        traceLog(`Server restart already in progress, ignoring ${changeType}`);
         return;
     }
 
     try {
         isRestartInProgress = true;
-        traceLog(`Updating KedroViz panel due to ${changeType.toLowerCase()}...`);
+        traceLog(`Updating KedroViz panel due to ${changeType}`);
 
         // Restart the language server to pick up changes
         await vscode.commands.executeCommand('kedro.restart');

--- a/src/common/kedroProjectFileWatchers.ts
+++ b/src/common/kedroProjectFileWatchers.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { traceLog } from './log/logging';
+import KedroVizPanel from '../webview/vizWebView';
+
+// Simple restart prevention
+let isRestartInProgress = false;
+
+/**
+ * Sets up file watchers in the Kedro project
+ * @param context Extension context for managing subscriptions
+ */
+export function setupKedroProjectFileWatchers(context: vscode.ExtensionContext): void {
+    // Watch for Kedro-specific files that affect the pipeline structure
+    const kedroConfigWatcher = vscode.workspace.createFileSystemWatcher('**/conf/**/*.{yml,yaml}');
+    const pipelinesFolderWatcher = vscode.workspace.createFileSystemWatcher('**/pipelines/**/*.py');
+    const pythonCatalogWatcher = vscode.workspace.createFileSystemWatcher('**/catalog*.py');
+
+    const handleFileChange = (uri: vscode.Uri, changeType: string) => {
+        traceLog(`${changeType}: ${uri.fsPath}`);
+        handleKedroProjectChange(uri, changeType);
+    };
+
+    // Set up change listeners
+    kedroConfigWatcher.onDidChange((uri) => handleFileChange(uri, 'Config changed'));
+    pipelinesFolderWatcher.onDidChange((uri) => handleFileChange(uri, 'Pipeline code changed'));
+    pythonCatalogWatcher.onDidChange((uri) => handleFileChange(uri, 'Python catalog changed'));
+
+    // Register for cleanup
+    context.subscriptions.push(kedroConfigWatcher, pipelinesFolderWatcher, pythonCatalogWatcher);
+
+    traceLog('Kedro file watchers initialized');
+}
+
+/**
+ * Handler for Kedro project file changes, Also prevents overlapping server restarts
+ */
+async function handleKedroProjectChange(uri: vscode.Uri, changeType: string): Promise<void> {
+    console.log(`${changeType}: ${uri.fsPath}`);
+
+    // Only update if KedroViz panel is currently open
+    if (!KedroVizPanel.currentPanel) {
+        traceLog('KedroViz panel not open, skipping update');
+        return;
+    }
+
+    // If restart is already in progress, ignore this change
+    if (isRestartInProgress) {
+        traceLog(`Server restart already in progress, ignoring ${changeType.toLowerCase()}`);
+        return;
+    }
+
+    try {
+        isRestartInProgress = true;
+        traceLog(`Updating KedroViz panel due to ${changeType.toLowerCase()}...`);
+
+        // Restart the language server to pick up changes
+        await vscode.commands.executeCommand('kedro.restart');
+
+        traceLog('Kedro server restarted successfully');
+    } catch (restartError) {
+        traceLog(`Server restart failed: ${restartError}`);
+    } finally {
+        isRestartInProgress = false;
+    }
+}

--- a/src/common/kedroProjectFileWatchers.ts
+++ b/src/common/kedroProjectFileWatchers.ts
@@ -10,7 +10,7 @@ let watchers: vscode.FileSystemWatcher[] = [];
  * Disposes of all existing file watchers
  */
 export function disposeKedroProjectFileWatchers(): void {
-    watchers.forEach(watcher => watcher.dispose());
+    watchers.forEach((watcher) => watcher.dispose());
     watchers = [];
     traceLog('Kedro file watchers disposed');
 }
@@ -25,7 +25,7 @@ export function setupKedroProjectFileWatchers(context: vscode.ExtensionContext):
 
     // Check if auto reload is enabled
     const config = vscode.workspace.getConfiguration('kedro');
-    const autoReloadEnabled = config.get<boolean>('autoReloadViz', false);
+    const autoReloadEnabled = config.get<boolean>('autoReloadKedroViz', false);
 
     if (!autoReloadEnabled) {
         traceLog('Auto reload is disabled, skipping file watchers setup');

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -75,6 +75,7 @@ export async function getWorkspaceSettings(
         isExperimental: config.get<string>(`isExperimental`) ?? 'yes',
         environment: config.get<string>(`environment`) ?? '',
         kedroProjectPath: config.get<string>(`kedroProjectPath`) ?? '',
+        autoReloadViz: config.get<boolean>(`autoReloadViz`) ?? false,
     };
     return workspaceSetting;
 }
@@ -106,6 +107,7 @@ export async function getGlobalSettings(namespace: string, includeInterpreter?: 
         isExperimental: getGlobalValue<string>(config, 'isExperimental', 'yes'),
         environment: getGlobalValue<string>(config, 'environment', ''),
         kedroProjectPath: getGlobalValue<string>(config, 'kedroProjectPath', ''),
+        autoReloadViz: getGlobalValue<boolean>(config, 'autoReloadViz', false),
     };
     return setting;
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -75,7 +75,7 @@ export async function getWorkspaceSettings(
         isExperimental: config.get<string>(`isExperimental`) ?? 'yes',
         environment: config.get<string>(`environment`) ?? '',
         kedroProjectPath: config.get<string>(`kedroProjectPath`) ?? '',
-        autoReloadViz: config.get<boolean>(`autoReloadViz`) ?? false,
+        autoReloadKedroViz: config.get<boolean>(`autoReloadKedroViz`) ?? false,
     };
     return workspaceSetting;
 }
@@ -107,7 +107,7 @@ export async function getGlobalSettings(namespace: string, includeInterpreter?: 
         isExperimental: getGlobalValue<string>(config, 'isExperimental', 'yes'),
         environment: getGlobalValue<string>(config, 'environment', ''),
         kedroProjectPath: getGlobalValue<string>(config, 'kedroProjectPath', ''),
-        autoReloadViz: getGlobalValue<boolean>(config, 'autoReloadViz', false),
+        autoReloadKedroViz: getGlobalValue<boolean>(config, 'autoReloadKedroViz', false),
     };
     return setting;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { traceError, traceLog, traceVerbose } from './common/log/logging';
 import { initializePython } from './common/python';
+import { setupKedroProjectFileWatchers } from './common/kedroProjectFileWatchers';
 
 import { getInterpreterFromSetting } from './common/settings';
 import { loadServerDefaults } from './common/setup';
@@ -68,6 +69,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             return;
         }
     }
+
+    setupKedroProjectFileWatchers(context);
 
     await installTelemetryDependenciesIfNeeded(context);
 


### PR DESCRIPTION
Resolves https://github.com/kedro-org/vscode-kedro/issues/195

## Description

This pull request introduces a new file watcher system for Kedro projects within the VS Code extension. When enabled, It  automatically detect changes to key Kedro project files (such as pipeline code, configuration, and catalog files) and trigger a restart of the Kedro language server, ensuring that the KedroViz panel stays up-to-date with the latest project data. The implementation also prevents overlapping server restarts for reliability.


### Note: 
By default, auto-reload in Kedro-Viz flowcharts is **disabled**, just like when running `kedro viz run` from the CLI. To enable it, users need to enable it in VS Code settings, similar to how the `--autoreload` option is passed in the CLI command.

## Developer notes

**Auto-Reload Feature for Kedro Viz:**

* Added a new configuration option `kedro.autoReloadViz` (boolean) to `package.json` to control whether Kedro Viz should automatically reload when project files change.
* Implemented the file watcher logic in the new `src/common/kedroProjectFileWatchers.ts` file, which watches relevant Kedro project files and triggers a server restart when changes are detected, provided the Kedro Viz panel is open.

**Integration with Extension Lifecycle:**

* Integrated the watcher setup into the extension activation (`src/extension.ts`), so watchers are initialized on startup. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R7) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R73-R74)
* Updated the command and event registration logic to re-initialize file watchers when the `autoReloadViz` setting changes, ensuring watchers are always in sync with user preferences (`src/common/activationHelper.ts`). [[1]](diffhunk://#diff-878744297d2b47b0f7e82d0c54a1c0d03e404741748a6c17c5a293c86f3a661bR17) [[2]](diffhunk://#diff-878744297d2b47b0f7e82d0c54a1c0d03e404741748a6c17c5a293c86f3a661bR130-R134)

**Settings Handling:**

* Extended the workspace and global settings retrieval functions to include the new `autoReloadViz` option, ensuring it is available throughout the extension (`src/common/settings.ts`). [[1]](diffhunk://#diff-3a5b47a3d2e56af22ee3eeb11a7ac02b69ac7b6bf52f9b48a870acd00da9f39aR78) [[2]](diffhunk://#diff-3a5b47a3d2e56af22ee3eeb11a7ac02b69ac7b6bf52f9b48a870acd00da9f39aR110)

## QA notes

- Checkout current branch
- Run make build, this will generate `.visx` file
- Paste/put generated `.vsix` file in your project/workspace 
- Locate `.vsix` file from VSCode explorer
- Right click on it and select "Install Extension VSIX" to install
- Make sure Kedro project opend at root
- Make sure correct virtual env is set for current Kedro project
- Open the Command Palette: Press Cmd + Shift + P (on macOS)
- Run Kedro-Viz: Type `kedro: Run Kedro Viz` and select the command
- Go to VSCode setting and enable "Auto reload Kedro-Viz"
- Make some change to any node name in `pipeline.py` and save it
- Above change will get reflected on flowchart after some time.