### PR TITLE
Toggle Kedro-Viz theme from VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,20 @@
                     "description": "Automatically reload Kedro Viz when Kedro project files change.",
                     "scope": "resource",
                     "type": "boolean"
+                },
+                "kedro.vizTheme": {
+                    "default": "dark",
+                    "description": "Theme for Kedro Viz visualization (light or dark).",
+                    "enum": [
+                        "light",
+                        "dark"
+                    ],
+                    "enumDescriptions": [
+                        "Light theme for Kedro Viz",
+                        "Dark theme for Kedro Viz"
+                    ],
+                    "scope": "resource",
+                    "type": "string"
                 }
             }
         },
@@ -225,6 +239,11 @@
             {
                 "command": "kedro.filterPipelines",
                 "title": "Select Pipeline View",
+                "category": "kedro"
+            },
+            {
+                "command": "kedro.toggleVizTheme",
+                "title": "Toggle Kedro Viz Theme",
                 "category": "kedro"
             }
         ]

--- a/src/common/activationHelper.ts
+++ b/src/common/activationHelper.ts
@@ -6,6 +6,7 @@ import {
     executeServerDefinitionCommand,
     setKedroProjectPath,
     filterPipelines,
+    toggleVizTheme,
 } from './commands';
 
 import * as vscode from 'vscode';
@@ -94,6 +95,7 @@ export const registerCommandsAndEvents = (
     const CMD_SHOW_OUTPUT_CHANNEL = `${serverId}.showOutputChannel`;
     const CMD_SET_PROJECT_PATH = `${serverId}.kedroProjectPath`;
     const CMD_FILTER_PIPELINES = `${serverId}.filterPipelines`;
+    const CMD_TOGGLE_VIZ_THEME = `${serverId}.toggleVizTheme`;
 
     (async () => {
         // Status Bar
@@ -183,6 +185,15 @@ export const registerCommandsAndEvents = (
             }),
             registerCommand(CMD_SET_PROJECT_PATH, () => {
                 setKedroProjectPath();
+            }),
+            registerCommand(CMD_TOGGLE_VIZ_THEME, async () => {
+                await toggleVizTheme();
+                // If KedroVizPanel is open, update the theme
+                if (KedroVizPanel.currentPanel) {
+                    const config = vscode.workspace.getConfiguration('kedro');
+                    const theme = config.get<string>('vizTheme', 'dark');
+                    KedroVizPanel.currentPanel.updateTheme(theme);
+                }
             }),
         );
     })();

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -211,3 +211,12 @@ export async function filterPipelines(lsClient?: LanguageClient) {
         );
     }
 }
+
+export async function toggleVizTheme() {
+    const config = vscode.workspace.getConfiguration('kedro');
+    const currentTheme = config.get<string>('vizTheme', 'dark');
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+    await config.update('vizTheme', newTheme, vscode.ConfigurationTarget.Workspace);
+    vscode.window.showInformationMessage(`Kedro Viz theme changed to ${newTheme}`);
+}

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -193,6 +193,12 @@ export async function updateKedroVizPanel(
 ): Promise<void> {
     const projectData = await executeGetProjectDataCommand(lsClient, pipelineName);
     KedroVizPanel.currentPanel?.updateData(projectData);
+
+    // Also send the current theme to the webview
+    const vscode = await import('vscode');
+    const config = vscode.workspace.getConfiguration('kedro');
+    const theme = config.get<string>('vizTheme', 'dark');
+    KedroVizPanel.currentPanel?.updateTheme(theme);
 }
 
 export async function isKedroProject(kedroProjectPath?: string): Promise<boolean> {

--- a/src/webview/vizWebView.ts
+++ b/src/webview/vizWebView.ts
@@ -92,6 +92,11 @@ export default class KedroVizPanel {
         this._panel.webview.postMessage({ command: 'updateData', data });
     }
 
+    public updateTheme(theme: string) {
+        // Send a message to the webview to update theme.
+        this._panel.webview.postMessage({ command: 'updateTheme', theme });
+    }
+
     public dispose() {
         KedroVizPanel.currentPanel = undefined;
 

--- a/webview/src/App.jsx
+++ b/webview/src/App.jsx
@@ -7,6 +7,7 @@ function App() {
   const [data, setData] = React.useState({ nodes: [], edges: [] });
   const [error, setError] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
+  const [theme, setTheme] = React.useState('dark');
 
   const toolbarOptions = {
     labelBtn: true,
@@ -34,8 +35,13 @@ function App() {
             setError(true);
           }
           break;
+        case "updateTheme":
+          if (message.theme) {
+            setTheme(message.theme);
+          }
+          break;
         default:
-          break;  
+          break;
       }
     });
 
@@ -117,7 +123,7 @@ function App() {
               sidebar: true,
               ...toolbarOptions,
             },
-            behaviour: { 
+            behaviour: {
               reFocus: false,
             },
             visible: {
@@ -125,6 +131,7 @@ function App() {
               sidebar: false,
             },
             layer: {visible: false},
+            theme: theme,
           }}
         />)}
     </div>


### PR DESCRIPTION
Fixes https://github.com/kedro-org/vscode-kedro/issues/188

This pull request introduces a new feature to allow users to toggle the theme (light or dark) for the Kedro Viz visualization from within the extension. It adds a user setting, a command to toggle the theme, updates the webview panel to support theme changes, and ensures the selected theme is communicated and applied in the visualization UI.

**Theme toggle and configuration support:**

* Added a new `kedro.vizTheme` setting in `package.json` to allow users to choose between "light" and "dark" themes for Kedro Viz.
* Introduced a new command `kedro.toggleVizTheme` to toggle the theme, updated command registration, and implemented the toggle logic in `commands.ts` and `activationHelper.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R243-R247) [[2]](diffhunk://#diff-878744297d2b47b0f7e82d0c54a1c0d03e404741748a6c17c5a293c86f3a661bR9) [[3]](diffhunk://#diff-878744297d2b47b0f7e82d0c54a1c0d03e404741748a6c17c5a293c86f3a661bR98) [[4]](diffhunk://#diff-878744297d2b47b0f7e82d0c54a1c0d03e404741748a6c17c5a293c86f3a661bR189-R197) [[5]](diffhunk://#diff-03343d08f355474487ba77c323e3e4125a81ceddd2fadfd75cf38d80e1e7fd09R214-R222)

**Webview integration:**

* Updated `KedroVizPanel` to include an `updateTheme` method, sending the current theme to the webview whenever it changes or when the panel is updated. [[1]](diffhunk://#diff-7d1502d4e9f8efd749d2014cb8015a9328d0078d0dc5a194b4cb0a381bd88fdbR196-R201) [[2]](diffhunk://#diff-ff0692c4996a8e631a550dc3fc4a44874cbe9d504c9165c62c11339244be2c73R95-R99)

**Frontend (React webview) support:**

* Modified the React frontend (`App.jsx`) to accept theme updates from the extension, store the theme in state, and pass it to the visualization component. [[1]](diffhunk://#diff-7eebeb518139a7bea347e0941b94f78541aee8a123b0a1c00ca7fe4267a46cddR10) [[2]](diffhunk://#diff-7eebeb518139a7bea347e0941b94f78541aee8a123b0a1c00ca7fe4267a46cddR38-R42) [[3]](diffhunk://#diff-7eebeb518139a7bea347e0941b94f78541aee8a123b0a1c00ca7fe4267a46cddR134)