### PR TITLE
Dependabot high severity fixes

### DIFF
--- a/webview/package-lock.json
+++ b/webview/package-lock.json
@@ -15466,9 +15466,9 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -15739,9 +15739,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }

--- a/webview/package.json
+++ b/webview/package.json
@@ -36,10 +36,11 @@
   "overrides": {
     "d3-color": "^3.1.0",
     "nth-check": "^2.1.1",
-    "minimatch@<3.1.3": "3.1.3",
+    "minimatch@<3.1.4": "3.1.4",
     "minimatch@>=5.0.0 <5.1.8": "5.1.8",
     "minimatch@>=9.0.0 <9.0.7": "9.0.7",
-    "serialize-javascript@<7.0.3": "7.0.3"
+    "serialize-javascript@<7.0.3": "7.0.3",
+    "node-forge@<1.3.2": "1.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",


### PR DESCRIPTION
This pull request updates dependency versions in the `webview` package to address security and compatibility issues. The most important changes are version bumps for `minimatch` and `node-forge` in both `package.json` and `package-lock.json`.

**Dependency updates:**

* Updated `minimatch` to version `3.1.4` in both `package-lock.json` and as an override in `package.json` to ensure the latest patch is used and address any known vulnerabilities. [[1]](diffhunk://#diff-d3561f25ea07737c4cb034bcd3389516804925653c682bd3ada022b22bd82d9fL15469-R15471) [[2]](diffhunk://#diff-768fcfde96b57f2af582e7c53e023e1532fbcc1c4ed8e1328fef74bedfc5f4f5L39-R43)
* Updated `node-forge` to version `1.3.2` in both `package-lock.json` and as an override in `package.json`, which also updates its license field. [[1]](diffhunk://#diff-d3561f25ea07737c4cb034bcd3389516804925653c682bd3ada022b22bd82d9fL15742-R15745) [[2]](diffhunk://#diff-768fcfde96b57f2af582e7c53e023e1532fbcc1c4ed8e1328fef74bedfc5f4f5L39-R43)