### PR TITLE
Mention Cursor support in Kedro VSCode repo and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -27,7 +27,7 @@ assignees: ''
 <!-- Tell us what should happen. -->
 
 ## Actual Result
-<!-- Tell us what happens instead. Click `Output` and select `Kedro` in VSCode, share the log if it is possible-->
+<!-- Tell us what happens instead. Click `Output` and select `Kedro` in VS Code / Cursor, share the log if it is possible-->
 
 ```
 -- If you received an error, place it here.
@@ -41,6 +41,7 @@ assignees: ''
 <!-- Include as many relevant details about the environment in which you experienced the bug: -->
 
 * Kedro version used (`pip show kedro` or `kedro -V`):
-* Kedro VSCode version used
+* Kedro extension version used
+* Editor and version used (VS Code or Cursor):
 * Python version used (`python -V`):
 * Operating system and version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 # Upcoming Release
+- Documented that the extension also works in [Cursor](https://cursor.com), which supports VS Code extensions and installs them from the Open VSX Registry.
 
 # 0.8.0
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,6 +26,8 @@
  1. [VSCode Marketplace](https://marketplace.visualstudio.com/manage/publishers/kedro/extensions/kedro)
  2. [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro)
 
+ > **Note:** The Open VSX Registry release is what makes the extension installable in [Cursor](https://cursor.com) (and other VS Code-compatible editors), which use Open VSX instead of the VS Code Marketplace. Keep both targets in sync when releasing.
+
  The release processes are as follow:
  1. Create a release branch named release/<version> from the HEAD of main. Following the release/<version> naming convention is essential when creating a tag/release in GitHub.
  2. Bump version number.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,7 +26,7 @@
  1. [VSCode Marketplace](https://marketplace.visualstudio.com/manage/publishers/kedro/extensions/kedro)
  2. [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro)
 
- > **Note:** The Open VSX Registry release is what makes the extension installable in [Cursor](https://cursor.com) (and other VS Code-compatible editors), which use Open VSX instead of the VS Code Marketplace. Keep both targets in sync when releasing.
+ > **Note:** The Open VSX Registry release makes the extension installable in [Cursor](https://cursor.com) (and other VS Code-compatible editors), which use Open VSX instead of the VS Code Marketplace. Keep both targets in sync when releasing.
 
  The release processes are as follow:
  1. Create a release branch named release/<version> from the HEAD of main. Following the release/<version> naming convention is essential when creating a tag/release in GitHub.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # vscode-kedro
 The extension integrates [Kedro](https://github.com/kedro-org/kedro) projects with Visual Studio Code, providing features like enhanced code navigation and autocompletion for seamless development.
 
+> ### Also works in Cursor!
+> This extension runs in **[Cursor](https://cursor.com)** exactly the same as in VS Code. Cursor is built on VS Code and supports VS Code extensions, so every feature below works there too. Install it from Cursor's Extensions panel (powered by the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro)) — no Cursor-specific setup required. See [Using the extension in Cursor](#using-the-extension-in-cursor).
+
 If you encounter issue, report it in [Github](https://github.com/kedro-org/vscode-kedro/issues) or [Slack](https://slack.kedro.org), we will try to fix ASAP.
 
 - [vscode-kedro](#vscode-kedro)
   - [Requirements](#requirements)
   - [How to use this extension](#how-to-use-this-extension)
+  - [Using the extension in Cursor](#using-the-extension-in-cursor)
 - [Recently added](#recently-added)
 - [Features](#features)
   - [Go to Definition from pipeline.py to configuration files](#go-to-definition-from-pipelinepy-to-configuration-files)
@@ -28,7 +32,7 @@ If you encounter issue, report it in [Github](https://github.com/kedro-org/vscod
   - [Troubleshooting](#troubleshooting)
 
 ## Requirements
-1. VS Code 1.78.0 or greater
+1. VS Code 1.78.0 or greater — **or [Cursor](https://cursor.com)** (Cursor is built on VS Code and supports VS Code extensions; see [Using the extension in Cursor](#using-the-extension-in-cursor))
 2. Python extension for VS Code
 3. Kedro Project >= 0.19
 
@@ -41,6 +45,17 @@ p.s. If you can `kedro run` with the environment, you are good to go.
 
 The extension requires `bootstrap_project` in Kedro, you need to make sure you can do `kedro run` without getting any immediate error, otherwise you may get a server panic error.
 
+## Using the extension in Cursor
+
+This extension also works in **[Cursor](https://cursor.com)**. Cursor is built on top of VS Code and supports VS Code extensions, so the Kedro extension behaves exactly the same there — all the features described below are available in Cursor.
+
+### Install in Cursor
+1. Open the **Extensions** panel in Cursor (`Cmd` + `Shift` + `X` on macOS, `Ctrl` + `Shift` + `X` on Windows/Linux).
+2. Search for **Kedro** and install it. Cursor installs extensions from the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro), where this extension is published.
+3. Make sure the **Python** extension is also installed — the Kedro extension depends on it.
+4. Select the Python interpreter for your Kedro project with `> Python: Select Interpreter`, then open your Cursor workspace at the root of the Kedro project.
+
+> **Note:** Setup is identical to VS Code — the only difference is that you install from Cursor's Extensions panel (Open VSX) rather than the VS Code Marketplace. No Cursor-specific configuration is required, and no editor-specific limitations have been found during testing.
 
 ## Recently added
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # vscode-kedro
 The extension integrates [Kedro](https://github.com/kedro-org/kedro) projects with Visual Studio Code, providing features like enhanced code navigation and autocompletion for seamless development.
 
-> ### Also works in Cursor!
-> This extension runs in **[Cursor](https://cursor.com)** exactly the same as in VS Code. Cursor is built on VS Code and supports VS Code extensions, so every feature below works there too. Install it from Cursor's Extensions panel (powered by the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro)) — no Cursor-specific setup required. See [Using the extension in Cursor](#using-the-extension-in-cursor).
+> ### Also works in Cursor
+> This extension runs in **[Cursor](https://cursor.com)** exactly the same as in VS Code. Cursor is built on VS Code and supports VS Code extensions, so every feature below works there too. Install it from Cursor's Extensions panel (powered by the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro))—no Cursor-specific setup required. See [Use the extension in Cursor](#use-the-extension-in-cursor).
 
 If you encounter issue, report it in [Github](https://github.com/kedro-org/vscode-kedro/issues) or [Slack](https://slack.kedro.org), we will try to fix ASAP.
 
 - [vscode-kedro](#vscode-kedro)
   - [Requirements](#requirements)
   - [How to use this extension](#how-to-use-this-extension)
-  - [Using the extension in Cursor](#using-the-extension-in-cursor)
+  - [Use the extension in Cursor](#use-the-extension-in-cursor)
 - [Recently added](#recently-added)
 - [Features](#features)
   - [Go to Definition from pipeline.py to configuration files](#go-to-definition-from-pipelinepy-to-configuration-files)
@@ -32,7 +32,7 @@ If you encounter issue, report it in [Github](https://github.com/kedro-org/vscod
   - [Troubleshooting](#troubleshooting)
 
 ## Requirements
-1. VS Code 1.78.0 or greater — **or [Cursor](https://cursor.com)** (Cursor is built on VS Code and supports VS Code extensions; see [Using the extension in Cursor](#using-the-extension-in-cursor))
+1. VS Code 1.78.0 or greater, **or [Cursor](https://cursor.com)** (Cursor is built on VS Code and supports VS Code extensions; see [Use the extension in Cursor](#use-the-extension-in-cursor))
 2. Python extension for VS Code
 3. Kedro Project >= 0.19
 
@@ -45,17 +45,17 @@ p.s. If you can `kedro run` with the environment, you are good to go.
 
 The extension requires `bootstrap_project` in Kedro, you need to make sure you can do `kedro run` without getting any immediate error, otherwise you may get a server panic error.
 
-## Using the extension in Cursor
+## Use the extension in Cursor
 
-This extension also works in **[Cursor](https://cursor.com)**. Cursor is built on top of VS Code and supports VS Code extensions, so the Kedro extension behaves exactly the same there — all the features described below are available in Cursor.
+This extension also works in **[Cursor](https://cursor.com)**. Cursor is built on VS Code and supports VS Code extensions, so the Kedro extension behaves exactly the same there. Every feature described below works in Cursor.
 
 ### Install in Cursor
 1. Open the **Extensions** panel in Cursor (`Cmd` + `Shift` + `X` on macOS, `Ctrl` + `Shift` + `X` on Windows/Linux).
-2. Search for **Kedro** and install it. Cursor installs extensions from the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro), where this extension is published.
-3. Make sure the **Python** extension is also installed — the Kedro extension depends on it.
+2. Search for **Kedro** and install it. Cursor installs extensions from the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro), which hosts this extension.
+3. Make sure the **Python** extension is also installed—the Kedro extension depends on it.
 4. Select the Python interpreter for your Kedro project with `> Python: Select Interpreter`, then open your Cursor workspace at the root of the Kedro project.
 
-> **Note:** Setup is identical to VS Code — the only difference is that you install from Cursor's Extensions panel (Open VSX) rather than the VS Code Marketplace. No Cursor-specific configuration is required, and no editor-specific limitations have been found during testing.
+> **Note:** Setup is identical to VS Code—the only difference is that you install from Cursor's Extensions panel (Open VSX) rather than the VS Code Marketplace. Cursor needs no extra configuration, and testing found no editor-specific limitations.
 
 ## Recently added
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you encounter issue, report it in [Github](https://github.com/kedro-org/vscod
   - [Troubleshooting](#troubleshooting)
 
 ## Requirements
-1. VS Code 1.78.0 or greater, **or [Cursor](https://cursor.com)** (Cursor is built on VS Code and supports VS Code extensions; see [Use the extension in Cursor](#use-the-extension-in-cursor))
+1. VS Code 1.78.0 or greater, **or [Cursor](https://cursor.com)** (See [Use the extension in Cursor](#use-the-extension-in-cursor))
 2. Python extension for VS Code
 3. Kedro Project >= 0.19
 
@@ -55,7 +55,7 @@ This extension also works in **[Cursor](https://cursor.com)**. Cursor is built o
 3. Make sure the **Python** extension is also installed—the Kedro extension depends on it.
 4. Select the Python interpreter for your Kedro project with `> Python: Select Interpreter`, then open your Cursor workspace at the root of the Kedro project.
 
-> **Note:** Setup is identical to VS Code—the only difference is that you install from Cursor's Extensions panel (Open VSX) rather than the VS Code Marketplace. Cursor needs no extra configuration, and testing found no editor-specific limitations.
+> **Note:** Setup is identical to VS Code—the only difference is that you install from Cursor's Extensions panel (Open VSX) rather than the VS Code Marketplace. Cursor needs no extra configuration.
 
 ## Recently added
 

--- a/assets/markdown/learn_more.md
+++ b/assets/markdown/learn_more.md
@@ -4,4 +4,4 @@
 - [Kedro-Viz documentation](https://docs.kedro.org/projects/kedro-viz/en/stable)
 - [Kedro VS Code extension documentation](https://marketplace.visualstudio.com/items?itemName=kedro.Kedro)
 
-**✨ Using Cursor?** This extension works in [Cursor](https://cursor.com) too — Cursor supports VS Code extensions. Install it from Cursor's Extensions panel via the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro); everything in this walkthrough applies the same way.
+**Using Cursor?** This extension works in [Cursor](https://cursor.com) too—Cursor supports VS Code extensions. Install it from Cursor's Extensions panel, powered by the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro). Everything in this walkthrough applies the same way.

--- a/assets/markdown/learn_more.md
+++ b/assets/markdown/learn_more.md
@@ -2,4 +2,6 @@
 
 - [Kedro documentation](https://docs.kedro.org/en/stable)
 - [Kedro-Viz documentation](https://docs.kedro.org/projects/kedro-viz/en/stable)
-- [Kedro VSCode extension documentation](https://marketplace.visualstudio.com/items?itemName=kedro.Kedro)
+- [Kedro VS Code extension documentation](https://marketplace.visualstudio.com/items?itemName=kedro.Kedro)
+
+**✨ Using Cursor?** This extension works in [Cursor](https://cursor.com) too — Cursor supports VS Code extensions. Install it from Cursor's Extensions panel via the [Open VSX Registry](https://open-vsx.org/extension/kedro/Kedro); everything in this walkthrough applies the same way.

--- a/assets/markdown/run_kedro-Viz.md
+++ b/assets/markdown/run_kedro-Viz.md
@@ -1,6 +1,6 @@
 # Install dependencies and run Kedro-Viz
 
-**Note:** For Kedro VS Code extension to work, please open a `.py` or `.yaml` file.
+**Note:** For the Kedro extension to work (in VS Code or Cursor), please open a `.py` or `.yaml` file.
 
 ### 5.1 Run Kedro Viz
    - Press `Cmd` + `Shift` + `P` (on macOS) or `Ctrl` + `Shift` + `P` (on Windows/Linux)

--- a/assets/markdown/run_kedro-Viz.md
+++ b/assets/markdown/run_kedro-Viz.md
@@ -1,6 +1,6 @@
 # Install dependencies and run Kedro-Viz
 
-**Note:** For the Kedro extension to work (in VS Code or Cursor), please open a `.py` or `.yaml` file.
+**Note:** For the Kedro extension to work (in VS Code or Cursor), open a `.py` or `.yaml` file.
 
 ### 5.1 Run Kedro Viz
    - Press `Cmd` + `Shift` + `P` (on macOS) or `Ctrl` + `Shift` + `P` (on Windows/Linux)

--- a/assets/markdown/set_project_path.md
+++ b/assets/markdown/set_project_path.md
@@ -5,7 +5,7 @@ Please refer to “Set Custom Kedro Project Path” in https://marketplace.visua
 
 ### 2.2 How to get the absolute path of your Kedro project
 
-   - Press `Cmd` + `Shift` + `E` (on macOS) or `Ctrl` + `Shift` + `E` (on Windows/Linux) to open VSCode explorer
+   - Press `Cmd` + `Shift` + `E` (on macOS) or `Ctrl` + `Shift` + `E` (on Windows/Linux) to open the VS Code (or Cursor) explorer
    - Locate your Kedro project folder
    - Right click on it and select `Copy path`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Kedro",
     "displayName": "Kedro",
-    "description": "A Kedro VSCode Extension.",
+    "description": "A Kedro extension for Visual Studio Code and Cursor.",
     "version": "0.8.0",
     "preview": false,
     "serverInfo": {
@@ -27,7 +27,8 @@
         "python",
         "kedro",
         "development tool",
-        "machine learning"
+        "machine learning",
+        "cursor"
     ],
     "engines": {
         "vscode": "^1.78.0"
@@ -167,7 +168,7 @@
             {
                 "id": "kedro-extension-setup",
                 "title": "Get Started with Kedro",
-                "description": "Learn how to set up and run a Kedro project, and visualize your pipeline in VS Code using the Kedro extension.",
+                "description": "Learn how to set up and run a Kedro project, and visualize your pipeline in VS Code or Cursor using the Kedro extension.",
                 "steps": [
                     {
                         "id": "setup-kedro",


### PR DESCRIPTION
fixes https://github.com/kedro-org/vscode-kedro/issues/339

This pull request updates documentation and metadata to clarify that the Kedro extension works seamlessly in both Visual Studio Code and Cursor, a VS Code-compatible editor. The changes ensure that users of Cursor are informed that all features are supported and provide installation instructions specific to Cursor. 

**Documentation updates for Cursor support:**

* Added prominent notes and sections in `README.md` describing Cursor compatibility, installation steps, and requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R4-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R35) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R58)
* Updated `DEVELOPMENT.md` to mention that releases to the Open VSX Registry make the extension available in Cursor and other VS Code-compatible editors.
* Added a note in `assets/markdown/learn_more.md` highlighting that the extension works in Cursor and how to install it.
* Updated usage instructions and messaging in `assets/markdown/run_kedro-Viz.md` and `assets/markdown/set_project_path.md` to reference VS Code and Cursor together. [[1]](diffhunk://#diff-7700ff937bcb3406c78bf346ddd38f57933ce2f8e8130c717b270f72369a7f98L3-R3) [[2]](diffhunk://#diff-146edbc4eadda70423121c780ffe9f692733d9f02342984cfd136d1048b5b0d5L8-R8)
* Improved the bug report template to refer to both VS Code and Cursor, and to request information about the editor and extension version. [[1]](diffhunk://#diff-5870a741e2fa8d0b03a88d7b036d408ee7e6954051fcc5d7978269bf6d1ff242L30-R30) [[2]](diffhunk://#diff-5870a741e2fa8d0b03a88d7b036d408ee7e6954051fcc5d7978269bf6d1ff242L44-R45)

