### PR TITLE
fix: don't validate catalog files inside .venv / dependency dirs

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -633,8 +633,18 @@ async def validate_all_catalogs(ls: KedroLanguageServer):
 
 def find_all_catalog_files(root_path):
     """Find all catalog files in the workspace."""
+    # Directories that hold third-party packages or tooling state rather than
+    # the user's project (e.g. kedro ships a cookiecutter template whose
+    # catalog.yml is intentionally invalid). Descending into these produces
+    # spurious "Invalid catalog format" diagnostics, so skip them.
+    ignored_dirs = {"node_modules", "__pycache__", "site-packages", "venv", "env"}
     catalog_files = []
-    for dirpath, _, filenames in os.walk(root_path):
+    for dirpath, dirnames, filenames in os.walk(root_path):
+        # Prune hidden dirs (e.g. .venv, .git, .tox) and dependency dirs in
+        # place so os.walk does not descend into them.
+        dirnames[:] = [
+            d for d in dirnames if not d.startswith(".") and d not in ignored_dirs
+        ]
         for filename in filenames:
             if filename.startswith('catalog') and filename.endswith(('.yml', '.yaml')):
                 file_path = os.path.join(dirpath, filename)


### PR DESCRIPTION
Fixes #276

## Problem

`find_all_catalog_files()` walks the whole workspace with `os.walk` and no directory pruning:

```python
for dirpath, _, filenames in os.walk(root_path):
    for filename in filenames:
        if filename.startswith('catalog') and filename.endswith(('.yml', '.yaml')):
            ...
```

So it descends into `.venv/.../site-packages` and picks up **kedro's shipped cookiecutter template** `catalog.yml`, which is intentionally invalid YAML (it contains `{{ cookiecutter... }}` placeholders). That template then fails validation and surfaces a spurious `Invalid catalog format` diagnostic that doesn't correspond to anything in the user's project.

## Fix

Prune hidden directories (`.venv`, `.git`, `.tox`, ...) and common dependency directories (`site-packages`, `node_modules`, `venv`, `env`, `__pycache__`) in place, so `os.walk` never descends into them:

```python
dirnames[:] = [
    d for d in dirnames if not d.startswith(".") and d not in ignored_dirs
]
```

Modifying `dirnames` in place is the standard way to prune an `os.walk`. This matches the approach discussed on the issue. Verifiable by inspection; only the user's own project directories are walked now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)