### PR TITLE
fix: consolidate root npm security updates and unblock CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -96,7 +96,12 @@ def _update_npm_packages(session: nox.Session) -> None:
 
 
 def _setup_template_environment(session: nox.Session) -> None:
-    session.install("wheel", "pip-tools")
+    # pip-tools 7.6.0 has two packaging problems we have to work around:
+    #  * it imports `typing_extensions` on Python < 3.11 without declaring it,
+    #  * it calls pip's internal `make_requirement_preparer()`, whose signature
+    #    changed in pip 26.2.
+    # Both make `pip-compile` fail on import/run rather than at resolution time.
+    session.install("wheel", "pip<26.2", "pip-tools", "typing_extensions")
     session.run(
         "pip-compile",
         # "--generate-hashes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache2",
             "dependencies": {
                 "@vscode/python-extension": "^1.0.6",
-                "axios": "^1.15.2",
+                "axios": "^1.18.0",
                 "fs-extra": "^11.3.5",
                 "globby": "^11.1.0",
                 "vscode-languageclient": "^8.1.0"
@@ -266,12 +266,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -280,29 +281,32 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-            "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-            "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.3",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.4",
-                "@babel/parser": "^7.28.4",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.4",
-                "@babel/types": "^7.28.4",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -328,13 +332,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-            "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.28.3",
-                "@babel/types": "^7.28.2",
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -344,13 +349,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.27.2",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -364,6 +370,7 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -373,6 +380,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -381,39 +389,43 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.28.3"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -433,52 +445,57 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.4"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -721,31 +738,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.2",
-                "@babel/types": "^7.27.1"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.3",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.4",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.8",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.8",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -753,13 +772,14 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -779,29 +799,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/wasi-threads": {
@@ -863,10 +860,11 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -910,10 +908,11 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1004,9 +1003,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2007,9 +2006,9 @@
             "license": "MIT"
         },
         "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2362,6 +2361,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
             "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.13.0",
                 "@typescript-eslint/types": "7.13.0",
@@ -3150,6 +3150,17 @@
                 "win32"
             ]
         },
+        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/@vscode/vsce/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3161,16 +3172,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -3398,6 +3399,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3591,16 +3593,17 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+            "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
+                "form-data": "^4.0.6",
                 "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
@@ -3870,6 +3873,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -3955,6 +3959,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -4273,6 +4278,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -4495,6 +4501,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -4601,6 +4608,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -4745,6 +4753,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -4765,9 +4774,10 @@
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -4779,6 +4789,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -4813,6 +4824,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4892,10 +4904,11 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5122,9 +5135,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -5280,19 +5293,31 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/form-data/node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/fs-constants": {
@@ -5366,6 +5391,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -5399,6 +5425,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -5482,9 +5509,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5548,6 +5575,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5611,6 +5639,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5622,6 +5651,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -6123,6 +6153,7 @@
             "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "30.4.2",
                 "@jest/types": "30.4.1",
@@ -7007,10 +7038,20 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -7233,10 +7274,21 @@
             "license": "MIT"
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
             }
@@ -7410,14 +7462,25 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+            "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "entities": "^4.5.0",
+                "linkify-it": "^5.0.2",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -7430,6 +7493,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -8333,9 +8397,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -8632,10 +8696,11 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8758,6 +8823,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -8943,10 +9009,14 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -9723,9 +9793,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9791,10 +9861,11 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.14"
             }
@@ -10000,6 +10071,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -10012,7 +10084,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uglify-js": {
             "version": "3.19.3",
@@ -10266,6 +10339,7 @@
             "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -10314,6 +10388,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     },
     "dependencies": {
         "@vscode/python-extension": "^1.0.6",
-        "axios": "^1.15.2",
+        "axios": "^1.18.0",
         "fs-extra": "^11.3.5",
         "globby": "^11.1.0",
         "vscode-languageclient": "^8.1.0"
@@ -300,16 +300,24 @@
         "serialize-javascript@<7.0.5": "7.0.5",
         "jws@>=3.0.0 <3.2.3": "3.2.3",
         "jws@>=4.0.0 <4.0.1": "4.0.1",
-        "js-yaml@>=3.0.0 <3.14.2": "3.14.2",
-        "qs@<6.14.2": "6.14.2",
         "flatted": "^3.4.2",
-        "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
         "handlebars": "^4.7.9",
         "picomatch": "^2.3.2",
         "lodash": "^4.18.1",
         "lodash-es": "^4.18.1",
-        "js-yaml@>=4.0.0 <4.1.1": "4.1.1",
-        "fast-uri": "^3.1.2"
+        "fast-uri": "^3.1.4",
+        "js-yaml@>=3.0.0 <3.15.0": "3.15.0",
+        "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
+        "qs@<6.15.2": "6.15.2",
+        "brace-expansion@>=1.0.0 <1.1.16": "1.1.16",
+        "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
+        "brace-expansion@>=3.0.0 <5.0.7": "5.0.7",
+        "linkify-it": "^5.0.2",
+        "shell-quote": "^1.10.0",
+        "form-data": "^4.0.6",
+        "markdown-it": "^14.2.0",
+        "tmp": "^0.2.6",
+        "@babel/core": "^7.29.6"
     },
     "devDependencies": {
         "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
## Summary

Resolves **26 open Dependabot alerts** against the root `package-lock.json` in a single change, and fixes the pre-existing `install` job failure.

## CI fix (`noxfile.py`)

`pip-tools` 7.6.0 has two packaging problems:

1. It imports `typing_extensions` on Python < 3.11 without declaring it as a dependency.
2. It calls pip's internal `make_requirement_preparer()`, whose signature changed in pip 26.2.

Either one makes `pip-compile` fail on import/run, which took down `nox --session build_package` — and with it `make dev-install`, so the publish workflow was broken too.

**Fix:** pin pip below `26.2` and install `typing_extensions` explicitly. The pip pin can be dropped once `pip-tools` ships a compatible release.

## Dependency fixes

- `axios` `^1.15.2` → `^1.18.0` (direct dependency, 10 alerts)
- Refresh three overrides that pinned versions now vulnerable themselves:
  - `js-yaml` `3.14.2` / `4.1.1` → `3.15.0` / `4.3.0`
  - `qs` `6.14.2` → `6.15.2`
- Widen `brace-expansion` coverage to the `1.x` and `5.x` lines
- Add overrides for `fast-uri`, `linkify-it`, `shell-quote`, `form-data`, `markdown-it`, `tmp` and `@babel/core`

## Supersedes

Closes out the following PRs, which all edit `package-lock.json` and therefore block each other:

- #368
- #366
- #364
- #363
- #350
- #345

## Alerts deliberately left open

**`uuid` (https://github.com/kedro-org/vscode-kedro/security/dependabot/226)** — reachable only via `@azure/msal-node`, which uses `uuid` v4, while the CVE affects v3/v5/v6 with a `buf` argument. Forcing `8` → `11` across three majors on the publishing path is not worth it.

**`dompurify` (https://github.com/kedro-org/vscode-kedro/security/dependabot/235)** — no patched version exists upstream.

## Verification

- [x] `npm install` completes cleanly
- [x] webpack production build succeeds
- [x] `jest` — 20/20 passing
- [x] `eslint` — 0 errors
- [x] `tsc` error count unchanged from `main` (19, all pre-existing in dependency `.d.ts` files)
- [x] `nox --session setup` now completes on Python 3.10